### PR TITLE
СlickHouse SQL Sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,14 @@ Provides `ClickHouseHook` and `ClickHouseOperator` for [Apache Airflow][airflow]
     as various timeouts, `compression`, `secure`, etc through Airflow
     [Connection.extra][airflow-conn-extra] property.
 
-# Installation
+# Installation and dependencies
 
 `pip install -U airflow-clickhouse-plugin`
+
+Requires `apache-airflow` and `clickhouse-driver`. Primarily supports Airflow
+    1.10.6 since it is the latest version
+    [supported by Google Cloud Composer][cloud-composer-versions]: later
+    versions are expected to work properly but may be not fully tested.
 
 # Usage
 
@@ -236,3 +241,4 @@ From the root project directory: `python -m unittest discover -s tests`
 [airflow-conn-dejson]: https://airflow.apache.org/docs/1.10.6/_api/airflow/models/index.html?highlight=connection#airflow.models.Connection.extra_dejson
 [airflow-conn-env]: https://airflow.apache.org/docs/stable/howto/connection/index.html#storing-a-connection-in-environment-variables
 [python-dbapi2-fetchone]: https://www.python.org/dev/peps/pep-0249/#fetchone
+[cloud-composer-versions]: https://cloud.google.com/composer/docs/concepts/versioning/composer-versions#supported_versions

--- a/airflow_clickhouse_plugin/__init__.py
+++ b/airflow_clickhouse_plugin/__init__.py
@@ -1,6 +1,7 @@
 from airflow.plugins_manager import AirflowPlugin
 from .hooks.clickhouse_hook import ClickHouseHook
 from .operators.clickhouse_operator import ClickHouseOperator
+from .sensors.clickhouse_sql_sensor import ClickHouseSqlSensor
 
 
 class ClickHouseOperatorPlugin(AirflowPlugin):
@@ -11,3 +12,8 @@ class ClickHouseOperatorPlugin(AirflowPlugin):
 class ClickHouseHookPlugin(AirflowPlugin):
     name = 'clickhouse_hook'
     hooks = [ClickHouseHook]
+
+
+class ClickHouseSqlSensorPlugin(AirflowPlugin):
+    name = 'clickhouse_sql_sensor'
+    sensors = [ClickHouseSqlSensor]

--- a/airflow_clickhouse_plugin/__version__.py
+++ b/airflow_clickhouse_plugin/__version__.py
@@ -9,7 +9,7 @@ __title__ = 'airflow-clickhouse-plugin'
 __description__ = \
     'airflow-clickhouse-plugin - ' \
     'Airflow plugin to execute ClickHouse commands and queries'
-__version__ = '0.5.6'
+__version__ = '0.5.7'
 __url__ = 'https://github.com/whisklabs/airflow-clickhouse-plugin'
 __license__ = 'MIT License'
 __author__ = 'Viktor Taranenko'

--- a/airflow_clickhouse_plugin/sensors/__init__.py
+++ b/airflow_clickhouse_plugin/sensors/__init__.py
@@ -1,0 +1,1 @@
+from .clickhouse_sql_sensor import ClickHouseSqlSensor

--- a/airflow_clickhouse_plugin/sensors/clickhouse_sql_sensor.py
+++ b/airflow_clickhouse_plugin/sensors/clickhouse_sql_sensor.py
@@ -1,0 +1,91 @@
+from typing import Dict, Callable, Any, Optional
+
+from airflow.exceptions import AirflowException
+from airflow.sensors.sql_sensor import SqlSensor
+from airflow_clickhouse_plugin.hooks.clickhouse_hook import ClickHouseHook
+
+
+class ClickHouseSqlSensor(SqlSensor):
+    _DEFAULT_CONN_ID = 'clickhouse_default'
+
+    def __init__(
+        self,
+        sql: str = None,
+        clickhouse_conn_id: str = _DEFAULT_CONN_ID,
+        parameters: Dict[str, Any] = None,
+        database: str = None,
+        success: Callable[[Any], bool] = None,
+        failure: Callable[[Any], bool] = None,
+        fail_on_empty: bool = False,
+        allow_null: bool = True,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(
+            conn_id=clickhouse_conn_id,
+            sql=sql,
+            parameters=parameters,
+            success=success,
+            failure=failure,
+            fail_on_empty=fail_on_empty,
+            *args,
+            **kwargs,
+        )
+        self._database = database
+        self.allow_null = allow_null
+
+    def _get_hook(self) -> ClickHouseHook:
+        return ClickHouseHook(clickhouse_conn_id=self.conn_id, database=self._database)
+
+    def poke(self, context: Optional[Dict[str, Any]]) -> bool:
+        """
+        Since Airflow 1.10.7 SqlSensor uses _get_hook to get database hook.
+        """
+        if hasattr(super(), '_get_hook'):
+            return super().poke(context)
+        else:
+            return self.__poke_backport()
+
+    def __poke_backport(self) -> bool:
+        """
+        https://github.com/apache/airflow/blob/1.10.10/airflow/sensors/sql_sensor.py#L86
+        """
+
+        hook = self._get_hook()
+
+        self.log.info('Poking: %s (with parameters %s)', self.sql, self.parameters)
+        records = hook.get_records(self.sql, self.parameters)
+        if not records:
+            if self.fail_on_empty:
+                raise AirflowException(
+                    'No rows returned, raising as per fail_on_empty flag'
+                )
+            else:
+                return False
+        first_cell = records[0][0]
+        if self.failure is not None:
+            if callable(self.failure):
+                if self.failure(first_cell):
+                    raise AirflowException(
+                        'Failure criteria met. self.failure({}) returned True'.format(
+                            first_cell
+                        )
+                    )
+            else:
+                raise AirflowException(
+                    'self.failure is present, but not callable -> {}'.format(
+                        self.success
+                    )
+                )
+        if self.success is not None:
+            if callable(self.success):
+                return self.success(first_cell)
+            else:
+                raise AirflowException(
+                    'self.success is present, but not callable -> {}'.format(
+                        self.success
+                    )
+                )
+        if self.allow_null:
+            return first_cell is None or bool(first_cell)
+        return bool(first_cell)

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ setup(
                 '= airflow_clickhouse_plugin:ClickHouseHookPlugin',
             'airflow_clickhouse_operator '
                 '= airflow_clickhouse_plugin:ClickHouseOperatorPlugin',
+            'airflow_clickhouse_sql_sensor '
+                '= airflow_clickhouse_plugin:ClickHouseSqlSensorPlugin',
         ]
     },
     classifiers=[

--- a/tests/integration/test_sql_sensor.py
+++ b/tests/integration/test_sql_sensor.py
@@ -1,0 +1,19 @@
+import unittest
+
+from airflow_clickhouse_plugin import ClickHouseSqlSensor
+
+
+class BasicTestCase(unittest.TestCase):
+    def test_sql_sensor(self):
+        self.assertFalse(ClickHouseSqlSensor(task_id='test', sql='SELECT 0').poke(None))
+        self.assertTrue(ClickHouseSqlSensor(task_id='test', sql='SELECT 1').poke(None))
+        self.assertTrue(
+            ClickHouseSqlSensor(task_id='test', sql='SELECT NULL').poke(None)
+        )
+        self.assertFalse(
+            ClickHouseSqlSensor(task_id='test', sql='SELECT 1 WHERE 0').poke(None)
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/integration/test_sql_sensor.py
+++ b/tests/integration/test_sql_sensor.py
@@ -5,13 +5,17 @@ from airflow_clickhouse_plugin import ClickHouseSqlSensor
 
 class BasicTestCase(unittest.TestCase):
     def test_sql_sensor(self):
-        self.assertFalse(ClickHouseSqlSensor(task_id='test', sql='SELECT 0').poke(None))
-        self.assertTrue(ClickHouseSqlSensor(task_id='test', sql='SELECT 1').poke(None))
+        self.assertFalse(
+            ClickHouseSqlSensor(task_id='_', sql='SELECT 0').poke(None),
+        )
         self.assertTrue(
-            ClickHouseSqlSensor(task_id='test', sql='SELECT NULL').poke(None)
+            ClickHouseSqlSensor(task_id='_', sql='SELECT 1').poke(None),
+        )
+        self.assertTrue(
+            ClickHouseSqlSensor(task_id='_', sql='SELECT NULL').poke(None),
         )
         self.assertFalse(
-            ClickHouseSqlSensor(task_id='test', sql='SELECT 1 WHERE 0').poke(None)
+            ClickHouseSqlSensor(task_id='_', sql='SELECT 1 WHERE 0').poke(None),
         )
 
 

--- a/tests/unit/test_sql_sensor.py
+++ b/tests/unit/test_sql_sensor.py
@@ -17,7 +17,6 @@ class ClickHouseSqlSensorTestCase(unittest.TestCase):
         mock_get_records.return_value = []
         self.assertFalse(op.poke(None))
 
-        # this behavior was changed in future versions
         mock_get_records.return_value = [[None]]
         self.assertTrue(op.poke(None))
 
@@ -25,13 +24,13 @@ class ClickHouseSqlSensorTestCase(unittest.TestCase):
         self.assertTrue(op.poke(None))
 
         mock_get_records.return_value = [[0.0]]
-        self.assertFalse(op.poke(None))
+        self.assertTrue(op.poke(None))
 
         mock_get_records.return_value = [[0]]
         self.assertFalse(op.poke(None))
 
         mock_get_records.return_value = [['0']]
-        self.assertTrue(op.poke(None))
+        self.assertFalse(op.poke(None))
 
         mock_get_records.return_value = [['1']]
         self.assertTrue(op.poke(None))

--- a/tests/unit/test_sql_sensor.py
+++ b/tests/unit/test_sql_sensor.py
@@ -2,7 +2,7 @@ import unittest
 from unittest import mock
 
 from airflow.exceptions import AirflowException
-from airflow.operators.sensors import SqlSensor
+from airflow.sensors.sql_sensor import SqlSensor
 
 from airflow_clickhouse_plugin import ClickHouseSqlSensor
 
@@ -132,20 +132,22 @@ class ClickHouseLegacySqlSensorTestCase(unittest.TestCase):
         'airflow_clickhouse_plugin.ClickHouseSqlSensor'
             '._ClickHouseSqlSensor__poke_clickhouse',
     )
-    @mock.patch(
-        'airflow_clickhouse_plugin.sensors.clickhouse_sql_sensor.SqlSensor',
-    )
+    @mock.patch('airflow.sensors.sql_sensor.SqlSensor.poke')
+    @mock.patch('airflow.sensors.sql_sensor.SqlSensor._get_hook', create=True)
     def test_get_hook_missing(
             self,
-            sql_sensor_mock: mock.MagicMock,
+            sql_sensor_get_hook_mock: mock.MagicMock,
+            sql_sensor_poke_mock: mock.MagicMock,
             clickhouse_sensor_poke_mock: mock.MagicMock,
     ):
         """ Test for case when ``SqlSensor._get_hook`` method is present. """
         op = ClickHouseSqlSensor(task_id='_', sql='')
-        delattr(sql_sensor_mock, '_get_hook')
+        del SqlSensor._get_hook
         op.poke(context=None)
-        sql_sensor_mock.poke.assert_not_called()
+        sql_sensor_poke_mock.assert_not_called()
         clickhouse_sensor_poke_mock.assert_called_once_with()
+        # line below prevents AttributeError on patch exit
+        SqlSensor._get_hook = sql_sensor_get_hook_mock
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_sql_sensor.py
+++ b/tests/unit/test_sql_sensor.py
@@ -1,0 +1,156 @@
+import unittest
+from unittest import mock
+
+from airflow.exceptions import AirflowException
+from airflow_clickhouse_plugin import ClickHouseSqlSensor
+
+
+class ClickHouseSqlSensorTestCase(unittest.TestCase):
+    @mock.patch(
+        'airflow_clickhouse_plugin.sensors.clickhouse_sql_sensor.ClickHouseHook'
+    )
+    def test_clickhouse_sql_sensor_poke(self, mock_hook):
+        op = ClickHouseSqlSensor(task_id='sql_sensor_check', sql='SELECT 1',)
+
+        mock_get_records = mock_hook().get_records
+
+        mock_get_records.return_value = []
+        self.assertFalse(op.poke(None))
+
+        # this behavior was changed in future versions
+        mock_get_records.return_value = [[None]]
+        self.assertTrue(op.poke(None))
+
+        mock_get_records.return_value = [['None']]
+        self.assertTrue(op.poke(None))
+
+        mock_get_records.return_value = [[0.0]]
+        self.assertFalse(op.poke(None))
+
+        mock_get_records.return_value = [[0]]
+        self.assertFalse(op.poke(None))
+
+        mock_get_records.return_value = [['0']]
+        self.assertTrue(op.poke(None))
+
+        mock_get_records.return_value = [['1']]
+        self.assertTrue(op.poke(None))
+
+    @mock.patch(
+        'airflow_clickhouse_plugin.sensors.clickhouse_sql_sensor.ClickHouseHook'
+    )
+    def test_clickhouse_sql_sensor_poke_fail_on_empty(self, mock_hook):
+        op = ClickHouseSqlSensor(
+            task_id='sql_sensor_check', sql='SELECT 1', fail_on_empty=True,
+        )
+
+        mock_get_records = mock_hook().get_records
+
+        mock_get_records.return_value = []
+        self.assertRaises(AirflowException, op.poke, None)
+
+    @mock.patch(
+        'airflow_clickhouse_plugin.sensors.clickhouse_sql_sensor.ClickHouseHook'
+    )
+    def test_clickhouse_sql_sensor_poke_success(self, mock_hook):
+        op = ClickHouseSqlSensor(
+            task_id='sql_sensor_check', sql='SELECT 1', success=lambda x: x in [1],
+        )
+
+        mock_get_records = mock_hook().get_records
+
+        mock_get_records.return_value = []
+        self.assertFalse(op.poke(None))
+
+        mock_get_records.return_value = [[1]]
+        self.assertTrue(op.poke(None))
+
+        mock_get_records.return_value = [['1']]
+        self.assertFalse(op.poke(None))
+
+    @mock.patch(
+        'airflow_clickhouse_plugin.sensors.clickhouse_sql_sensor.ClickHouseHook'
+    )
+    def test_clickhouse_sql_sensor_poke_failure(self, mock_hook):
+        op = ClickHouseSqlSensor(
+            task_id='sql_sensor_check', sql='SELECT 1', failure=lambda x: x in [1],
+        )
+
+        mock_get_records = mock_hook().get_records
+
+        mock_get_records.return_value = []
+        self.assertFalse(op.poke(None))
+
+        mock_get_records.return_value = [[1]]
+        self.assertRaises(AirflowException, op.poke, None)
+
+    @mock.patch(
+        'airflow_clickhouse_plugin.sensors.clickhouse_sql_sensor.ClickHouseHook'
+    )
+    def test_clickhouse_sql_sensor_poke_failure_success(self, mock_hook):
+        op = ClickHouseSqlSensor(
+            task_id='sql_sensor_check',
+            sql='SELECT 1',
+            failure=lambda x: x in [1],
+            success=lambda x: x in [2],
+        )
+
+        mock_get_records = mock_hook().get_records
+
+        mock_get_records.return_value = []
+        self.assertFalse(op.poke(None))
+
+        mock_get_records.return_value = [[1]]
+        self.assertRaises(AirflowException, op.poke, None)
+
+        mock_get_records.return_value = [[2]]
+        self.assertTrue(op.poke(None))
+
+    @mock.patch(
+        'airflow_clickhouse_plugin.sensors.clickhouse_sql_sensor.ClickHouseHook'
+    )
+    def test_clickhouse_sql_sensor_poke_failure_success_same(self, mock_hook):
+        op = ClickHouseSqlSensor(
+            task_id='sql_sensor_check',
+            sql='SELECT 1',
+            failure=lambda x: x in [1],
+            success=lambda x: x in [1],
+        )
+
+        mock_get_records = mock_hook().get_records
+
+        mock_get_records.return_value = []
+        self.assertFalse(op.poke(None))
+
+        mock_get_records.return_value = [[1]]
+        self.assertRaises(AirflowException, op.poke, None)
+
+    @mock.patch(
+        'airflow_clickhouse_plugin.sensors.clickhouse_sql_sensor.ClickHouseHook'
+    )
+    def test_clickhouse_sql_sensor_poke_invalid_failure(self, mock_hook):
+        op = ClickHouseSqlSensor(
+            task_id='sql_sensor_check', sql='SELECT 1', failure=[1],
+        )
+
+        mock_get_records = mock_hook().get_records
+
+        mock_get_records.return_value = [[1]]
+        self.assertRaises(AirflowException, op.poke, None)
+
+    @mock.patch(
+        'airflow_clickhouse_plugin.sensors.clickhouse_sql_sensor.ClickHouseHook'
+    )
+    def test_clickhouse_sql_sensor_poke_invalid_success(self, mock_hook):
+        op = ClickHouseSqlSensor(
+            task_id='sql_sensor_check', sql='SELECT 1', success=[1],
+        )
+
+        mock_get_records = mock_hook().get_records
+
+        mock_get_records.return_value = [[1]]
+        self.assertRaises(AirflowException, op.poke, None)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
@ne1ron please look through the tests.

It was a little bit tricky to patch the SqlSensor class in a proper way (especially speaking about attributes deletion, the clue was to [patch the right import](https://docs.python.org/3/library/unittest.mock.html#where-to-patch): `clickhouse_sql_sensor.SqlSensor` class instead of `airflow.sensors.SqlSensor`, [short mention on StackOverflow](https://stackoverflow.com/questions/51889049/unable-to-mock-class-that-inherits-from-another-class-which-creates-uses-single)), but I managed to test exactly what we wanted to test: attribute absence.

Also it is worth mentioning that instead of writing many tests for different versions of Airflow I decided to specify in README that we are currently only fully support Airflow 1.10.6. So it would be nice if you can run the tests on a later version of Airflow just for us to know how much does the behaviour differ from the one we are expecting in our tests now. I am speaking even not only about the unit tests but maybe to monitor the plugin behaviour in your production case. As soon as any information is available please write down to this PR even if it is already merged.

Please approve the PR and I will merge it and publish a new version.