### PR TITLE
Allow passing sql file paths to the template renderer

### DIFF
--- a/airflow_clickhouse_plugin/operators/clickhouse_operator.py
+++ b/airflow_clickhouse_plugin/operators/clickhouse_operator.py
@@ -8,6 +8,8 @@ from airflow_clickhouse_plugin.hooks.clickhouse_hook import ClickHouseHook
 
 class ClickHouseOperator(BaseOperator):
     template_fields = ('_sql',)
+    template_ext: Sequence[str] = ('.sql',)
+    template_fields_renderers = {"query": "sql"}
     default_conn_name = ClickHouseHook.default_conn_name
 
     def __init__(


### PR DESCRIPTION
https://airflow.apache.org/docs/apache-airflow/stable/howto/custom-operator.html#templating

When file paths that end in the .sql extension are passed, they will be rendered by Jinja properly.